### PR TITLE
Loosen dependencies on apt and stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,11 +11,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 2.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
These versions of both apt and stdlib are compatible and we'll be updating both of them shortly.