### PR TITLE
change owner/group for /var/run/php-fpm/ and /var/log/php-fpm/

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -107,8 +107,8 @@ class php::fpm::config (
   ensure_resource('file', '/var/run/php-fpm',
     {
       ensure => directory,
-      owner  => 'root',
-      group  => $root_group,
+      owner  => $user,
+      group  => $group,
       mode   => '0755',
     }
   )
@@ -116,8 +116,8 @@ class php::fpm::config (
   ensure_resource('file', '/var/log/php-fpm/',
     {
       ensure => directory,
-      owner  => 'root',
-      group  => $root_group,
+      owner  => $user,
+      group  => $group,
       mode   => $log_dir_mode,
     }
   )

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-php",
-  "version": "7.1.1-rc0",
+  "version": "7.1.2-rc0bc",
   "author": "Vox Pupuli",
   "summary": "Generic PHP module that supports many platforms",
   "license": "MIT",


### PR DESCRIPTION
## What?/Why?
This changes the `owner`/`group` for `/var/run/php-fpm/` and `/var/log/php-fpm/` in `manifests/fpm/config.pp` back to previous module version behavior for now to avoid any mishaps.

The new module version wants to change those to `root` / `$php::fpm::config::root_group` (which defaults to `$php::params::root_group` which is `root`) which will trigger a restart _and_ might cause permissions problems for log and pid files since those currently have `www-data` / `www-data` and owner / group,  respectively.

Additionally, I previously forgot to update the module's version in `metadata.json` so this sets that to `7.1.2-rc0bc`

## Impact
This is to avoid the potential negative impacts listed above.
Furthermore, this change will not be live until the ref for this module is updated in our puppet repository.

## Rollback
Revert this MR, update the puppet ref, re-run puppet on impacted nodes (very unexpected)